### PR TITLE
Fix black screen recording in Tauri by reverting canvas optimization …

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -330,15 +330,23 @@ function App() {
         }
 
         // MIMEタイプの優先順位を変更（MP4を優先）
+        // H.264 Baseline Profile (Safari friendly, safest for most environments)
         const mimeTypes = [
-            "video/mp4;codecs=avc1.4d002a", // H.264 Main Profile (Safari friendly)
             "video/mp4;codecs=avc1.42E01E", // H.264 Baseline Profile
+            "video/mp4;codecs=avc1.4d002a", // H.264 Main Profile
             'video/mp4; codecs="avc1.424028, mp4a.40.2"', // Constrained Baseline + AAC (Safe fallback)
             "video/mp4;codecs=h264",        // Generic H.264
             "video/mp4",                    // Generic MP4
             "video/webm;codecs=vp9",        // WebM fallback
             "video/webm"
         ];
+
+        // Tauri (WKWebView) 特定のフォールバック: Generic MP4を優先してみる
+        // Baseline Profileでもダメな場合、システムデフォルトに任せる
+        if (isTauri()) {
+             // 既存のリストの先頭に、より緩い定義を追加
+             mimeTypes.unshift("video/mp4");
+        }
         const mimeType = mimeTypes.find(type => MediaRecorder.isTypeSupported(type)) || "";
         console.log(`Recording with mimeType: ${mimeType}`);
 

--- a/src/components/Stage.tsx
+++ b/src/components/Stage.tsx
@@ -112,7 +112,7 @@ const Stage = forwardRef<StageRef, StageProps>(({
     getCanvasStream: () => {
         if (canvasRef.current) {
             // ストリーム取得
-            return canvasRef.current.captureStream(30);
+            return canvasRef.current.captureStream();
         }
         throw new Error("Canvas not initialized");
     },
@@ -126,13 +126,13 @@ const Stage = forwardRef<StageRef, StageProps>(({
     const canvas = canvasRef.current;
     if (!canvas) return;
 
-    // ★重要: alpha: false で不透明化して録画バグを防ぐ
-    // ★重要: Macアプリ対策セット
-    // willReadFrequently: true -> これが決定打！GPUを使わずCPUで描画させ、確実に録画できるようにする
+    // ★重要: Macアプリ対策 (Tauri/WKWebView)
+    // alpha: true (デフォルト) に戻す -> alpha: false だと録画が真っ黒になることがある
+    // willReadFrequently: false (デフォルト) に戻す -> captureStreamとの相性問題の可能性がある
     // preserveDrawingBuffer: true -> 念のため、描画バッファが消えないようにする
     const ctx = canvas.getContext('2d', { 
-        alpha: false,
-        willReadFrequently: true,
+        alpha: true,
+        willReadFrequently: false,
         preserveDrawingBuffer: true
     });
 


### PR DESCRIPTION
…and adjusting codecs

Reverted `willReadFrequently` to false and `alpha` to true in Canvas context to support WebKit hardware acceleration for recording. Prioritized generic `video/mp4` MIME type in Tauri to allow system default encoder selection.