### PR TITLE
fix: プロジェクトファイルに groups 保存を実装

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -268,6 +268,7 @@ function App() {
       projectName,
       dancers,
       keyframes,
+      groups,
       duration: playback.duration,
       audioFileName: audio.audioFileName,
     });

--- a/src/hooks/useProjectIO.ts
+++ b/src/hooks/useProjectIO.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { Dancer, Keyframe } from '../types';
+import { Dancer, Keyframe, Group } from '../types';
 import { isTauri } from '../utils/platform';
 import { save, open } from '@tauri-apps/plugin-dialog';
 import { writeTextFile, readTextFile } from '@tauri-apps/plugin-fs';
@@ -13,11 +13,22 @@ interface ProjectData {
   audioFileName: string | null;
 }
 
+interface ProjectDataV2 {
+  version: 2;
+  projectName: string;
+  dancers: Dancer[];
+  keyframes: Keyframe[];
+  groups: Group[];
+  duration: number;
+  audioFileName: string | null;
+}
+
 export interface ProjectIOAPI {
   saveProject: (params: {
     projectName: string;
     dancers: Dancer[];
     keyframes: Keyframe[];
+    groups: Group[];
     duration: number;
     audioFileName: string | null;
   }) => Promise<void>;
@@ -38,16 +49,18 @@ export function useProjectIO(): ProjectIOAPI {
     projectName: string;
     dancers: Dancer[];
     keyframes: Keyframe[];
+    groups: Group[];
     duration: number;
     audioFileName: string | null;
   }) => {
     try {
-      const { projectName, dancers, keyframes, duration, audioFileName } = params;
-      const projectData: ProjectData = {
-        version: 1,
+      const { projectName, dancers, keyframes, groups, duration, audioFileName } = params;
+      const projectData: ProjectDataV2 = {
+        version: 2,
         projectName,
         dancers,
         keyframes,
+        groups,
         duration,
         audioFileName,
       };
@@ -104,6 +117,20 @@ export function useProjectIO(): ProjectIOAPI {
             dancers: data.dancers || [],
             keyframes: data.keyframes || [],
             groups: [],
+          });
+          alert(`Project loaded! Please re-upload audio: ${data.audioFileName || 'None'}`);
+        } else if (data.version === 2) {
+          callbacks.setProjectName(data.projectName || 'Untitled Project');
+          callbacks.setDancers(data.dancers || []);
+          callbacks.setKeyframes(data.keyframes || []);
+          callbacks.setDuration(data.duration || 30000);
+          callbacks.setAudioFileName(data.audioFileName || null);
+          callbacks.setAudioFile(null);
+          callbacks.setAudioBuffer(null);
+          callbacks.setHistory({
+            dancers: data.dancers || [],
+            keyframes: data.keyframes || [],
+            groups: data.groups || [],
           });
           alert(`Project loaded! Please re-upload audio: ${data.audioFileName || 'None'}`);
         } else {


### PR DESCRIPTION
## Summary

プロジェクトファイルに groups を保存する機能を実装。

## Changes

- `ProjectDataV2` インターフェースを追加し、`groups: Group[]` を含める
- セマンティックバージョンを 2 に上げて後方互換性を維持（version 1 ファイル読み込み時は `groups: []`）
- `saveProject` / `loadProject` で groups の保存・復元を実装
- `App.tsx` の `handleSaveProject` に `groups` を渡すよう修正

## Testing

- TypeScript コンパイル (`tsc --noEmit`) ✅
- Vite ビルド (`npm run build`) ✅
- 既存の version 1 プロジェクトファイルは `groups: []` で正常に読み込み

Fixes happytown-s/ChoreoGraphManager#24