### PR TITLE
fix: #23 Fix memory leak and excessive JSON.stringify in useHistory

### DIFF
--- a/src/hooks/useHistory.ts
+++ b/src/hooks/useHistory.ts
@@ -1,4 +1,6 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef } from 'react';
+
+const MAX_HISTORY_SIZE = 100;
 
 export interface HistoryState<T> {
     past: T[];
@@ -15,12 +17,33 @@ export interface HistoryAPI {
     set: (state: any) => void;
 }
 
+function shallowEqual(a: unknown, b: unknown): boolean {
+    if (a === b) return true;
+    if (typeof a !== 'object' || a === null || typeof b !== 'object' || b === null) {
+        return false;
+    }
+    const keysA = Object.keys(a);
+    const keysB = Object.keys(b);
+    if (keysA.length !== keysB.length) return false;
+    for (const key of keysA) {
+        if (!Object.prototype.hasOwnProperty.call(b, key)) return false;
+        // Top-level shallow comparison: compare values by reference
+        if ((a as Record<string, unknown>)[key] !== (b as Record<string, unknown>)[key]) {
+            return false;
+        }
+    }
+    return true;
+}
+
 export function useHistory<T>(initialState: T) {
     const [state, setState] = useState<HistoryState<T>>({
         past: [],
         present: initialState,
         future: []
     });
+
+    // Track the last pushed state reference to skip redundant pushes cheaply
+    const lastPushedRef = useRef<T>(initialState);
 
     const canUndo = state.past.length > 0;
     const canRedo = state.future.length > 0;
@@ -57,13 +80,21 @@ export function useHistory<T>(initialState: T) {
 
     const pushState = useCallback((newState: T) => {
         setState(currentState => {
-            // If the new state is exactly the same as the present, don't push
-            if (JSON.stringify(currentState.present) === JSON.stringify(newState)) {
-                return currentState;
+            // Fast path: same reference means no change at all
+            if (newState === currentState.present) return currentState;
+            // Shallow equality check: if top-level keys point to the same references, skip
+            if (shallowEqual(newState, currentState.present)) return currentState;
+
+            // Trim past to MAX_HISTORY_SIZE by dropping oldest entries
+            const newPast = [...currentState.past, currentState.present];
+            if (newPast.length > MAX_HISTORY_SIZE) {
+                newPast.splice(0, newPast.length - MAX_HISTORY_SIZE);
             }
 
+            lastPushedRef.current = newState;
+
             return {
-                past: [...currentState.past, currentState.present],
+                past: newPast,
                 present: newState,
                 future: [] // Clear future on new action
             };
@@ -72,6 +103,7 @@ export function useHistory<T>(initialState: T) {
 
     // For setting state without pushing to history (e.g. initial load)
     const set = useCallback((newState: T) => {
+        lastPushedRef.current = newState;
         setState({
             past: [],
             present: newState,


### PR DESCRIPTION
## Summary

Fixes memory leak and performance issues in `useHistory` hook by:

- Replacing deep `JSON.stringify` comparison with shallow equality (reference-based top-level key check)
- Limiting past array length to 100 entries to prevent infinite memory growth
- Adding a fast-path same-reference check before any comparison

## Changes

- `src/hooks/useHistory.ts`: Updated history comparison logic, added `MAX_HISTORY_SIZE = 100` limit, introduced `shallowEqual` helper

## Testing

- TypeScript compilation passes (`tsc --noEmit`)
- Production build succeeds (`vite build`)

Fixes happytown-s/ChoreoGraphManager#23