### PR TITLE
fix: resolve audio recording, seek, and memory leak bugs

### DIFF
--- a/src/hooks/useAudio.ts
+++ b/src/hooks/useAudio.ts
@@ -25,6 +25,8 @@ export function useAudio(): AudioEngineAPI {
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const audioContextRef = useRef<AudioContext | null>(null);
   const audioDestNodeRef = useRef<MediaStreamAudioDestinationNode | null>(null);
+  // Track the previous ObjectURL so we can revoke it before creating a new one
+  const prevAudioUrlRef = useRef<string | null>(null);
 
   // Initialize AudioContext once
   useEffect(() => {
@@ -47,7 +49,12 @@ export function useAudio(): AudioEngineAPI {
   }, []);
 
   const handleAudioUpload = async (file: File) => {
+    // Revoke previous ObjectURL to prevent memory leak
+    if (prevAudioUrlRef.current) {
+      URL.revokeObjectURL(prevAudioUrlRef.current);
+    }
     const url = URL.createObjectURL(file);
+    prevAudioUrlRef.current = url;
     setAudioFile(url);
     setAudioFileName(file.name);
 

--- a/src/hooks/usePlayback.ts
+++ b/src/hooks/usePlayback.ts
@@ -24,7 +24,8 @@ export function usePlayback(audioRef: React.RefObject<HTMLAudioElement | null>, 
 
     const audio = audioRef.current;
     if (audio && audioFile) {
-      if (isPlaying) {
+      // Only pause if not currently playing (standard DAW UX keeps playback alive during seek)
+      if (!isPlaying) {
         setIsPlaying(false);
         audio.pause();
       }

--- a/src/hooks/useRecording.ts
+++ b/src/hooks/useRecording.ts
@@ -18,6 +18,9 @@ export function useRecording(projectName: string): RecordingAPI {
   const [isRecording, setIsRecording] = useState(false);
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const recordedChunksRef = useRef<Blob[]>([]);
+  // Track the audio element that was used to create MediaElementSource,
+  // so we never call createMediaElementSource twice on the same element.
+  const mediaElementSourceRef = useRef<{ element: HTMLAudioElement; source: MediaElementAudioSourceNode; ctx: AudioContext } | null>(null);
 
   const stopRecording = useCallback(() => {
     if (mediaRecorderRef.current && mediaRecorderRef.current.state !== 'inactive') {
@@ -98,12 +101,24 @@ export function useRecording(projectName: string): RecordingAPI {
         const audio = audioRef.current;
         if (audio && audioFile) {
           try {
-            const audioCtx = new AudioContext();
-            const source = audioCtx.createMediaElementSource(audio);
-            const dest = audioCtx.createMediaStreamDestination();
-            source.connect(dest);
-            source.connect(audioCtx.destination);
-            dest.stream.getAudioTracks().forEach(track => stream.addTrack(track));
+            // Reuse existing MediaElementSource if the audio element hasn't changed
+            if (mediaElementSourceRef.current && mediaElementSourceRef.current.element === audio) {
+              // Already connected — just grab the audio tracks from the existing destination
+              const { ctx, source } = mediaElementSourceRef.current;
+              const dest = ctx.createMediaStreamDestination();
+              source.connect(dest);
+              source.connect(ctx.destination);
+              dest.stream.getAudioTracks().forEach(track => stream.addTrack(track));
+            } else {
+              // First time for this audio element — create MediaElementSource
+              const audioCtx = new AudioContext();
+              const source = audioCtx.createMediaElementSource(audio);
+              const dest = audioCtx.createMediaStreamDestination();
+              source.connect(dest);
+              source.connect(audioCtx.destination);
+              mediaElementSourceRef.current = { element: audio, source, ctx: audioCtx };
+              dest.stream.getAudioTracks().forEach(track => stream.addTrack(track));
+            }
           } catch (e) {
             console.warn('[Recording] Could not capture audio element:', e);
           }


### PR DESCRIPTION
## Summary

Fixes three audio-related bugs:

- **#21** — 録画時に音声が消失する（MediaElementSourceの二重作成バグ）: `createMediaElementSource` was called every recording start, but it can only be called once per `<audio>` element. Now stored in a ref and reused.
- **#25** — 再生中のシークで意図せず一時停止する: Seeking during playback no longer pauses. Standard DAW UX keeps playback alive during seek.
- **#26** — URL.createObjectURL のメモリリーク: Previous ObjectURLs are now revoked before creating new ones on file upload.

## Changes

| File | Issue | Change |
|------|-------|--------|
| `src/hooks/useRecording.ts` | #21 | Store `MediaElementSource` in ref, reuse across recording sessions |
| `src/hooks/usePlayback.ts` | #25 | Skip pause when seeking during active playback |
| `src/hooks/useAudio.ts` | #26 | Revoke previous ObjectURL before creating new one |

## Test

- `npm run build` passes successfully